### PR TITLE
Add ObjectDB persistence setup and entity mappings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>3.1.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
             <version>21.0.6</version>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -10,7 +10,10 @@ module org.cerveza.cafe {
     requires org.kordamp.bootstrapfx.core;
     requires eu.hansolo.tilesfx;
     requires com.almasb.fxgl.all;
+    requires jakarta.persistence;
 
     opens org.cerveza.cafe to javafx.fxml;
     exports org.cerveza.cafe;
+    opens org.cerveza.cafe.model;
+    exports org.cerveza.cafe.model;
 }

--- a/src/main/java/org/cerveza/cafe/model/Cliente.java
+++ b/src/main/java/org/cerveza/cafe/model/Cliente.java
@@ -1,0 +1,88 @@
+package org.cerveza.cafe.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+@Entity
+@Table(name = "cliente")
+public class Cliente {
+
+    @Id
+    @Column(name = "id_cliente")
+    private Long id;
+
+    @Column(nullable = false)
+    private String nombre;
+
+    @Column
+    private String telefono;
+
+    @Column
+    private String correo;
+
+    @OneToMany(mappedBy = "cliente")
+    private Set<ProductoVendido> compras = new LinkedHashSet<>();
+
+    public Cliente() {
+    }
+
+    public Cliente(Long id, String nombre) {
+        this.id = id;
+        this.nombre = nombre;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public String getTelefono() {
+        return telefono;
+    }
+
+    public void setTelefono(String telefono) {
+        this.telefono = telefono;
+    }
+
+    public String getCorreo() {
+        return correo;
+    }
+
+    public void setCorreo(String correo) {
+        this.correo = correo;
+    }
+
+    public Set<ProductoVendido> getCompras() {
+        return compras;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Cliente cliente)) return false;
+        return Objects.equals(id, cliente.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/org/cerveza/cafe/model/Ingrediente.java
+++ b/src/main/java/org/cerveza/cafe/model/Ingrediente.java
@@ -1,0 +1,85 @@
+package org.cerveza.cafe.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+@Entity
+@Table(name = "ingredientes")
+public class Ingrediente {
+
+    @Id
+    @Column(name = "id_ingrediente")
+    private Long id;
+
+    @Column(nullable = false)
+    private String descripcion;
+
+    @Column
+    private String preparacion;
+
+    @OneToMany(mappedBy = "ingrediente")
+    private Set<ProporcionIngrediente> recetas = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "ingrediente")
+    private Set<IngredienteTienda> disponibilidad = new LinkedHashSet<>();
+
+    public Ingrediente() {
+    }
+
+    public Ingrediente(Long id, String descripcion, String preparacion) {
+        this.id = id;
+        this.descripcion = descripcion;
+        this.preparacion = preparacion;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getDescripcion() {
+        return descripcion;
+    }
+
+    public void setDescripcion(String descripcion) {
+        this.descripcion = descripcion;
+    }
+
+    public String getPreparacion() {
+        return preparacion;
+    }
+
+    public void setPreparacion(String preparacion) {
+        this.preparacion = preparacion;
+    }
+
+    public Set<ProporcionIngrediente> getRecetas() {
+        return recetas;
+    }
+
+    public Set<IngredienteTienda> getDisponibilidad() {
+        return disponibilidad;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Ingrediente that)) return false;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/org/cerveza/cafe/model/IngredienteTienda.java
+++ b/src/main/java/org/cerveza/cafe/model/IngredienteTienda.java
@@ -1,0 +1,111 @@
+package org.cerveza.cafe.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.Table;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Objects;
+
+@Entity
+@Table(name = "ingrediente_tienda")
+public class IngredienteTienda {
+
+    @EmbeddedId
+    private IngredienteTiendaId id = new IngredienteTiendaId();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("tiendaId")
+    @JoinColumn(name = "id_tienda", nullable = false)
+    private Tienda tienda;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("ingredienteId")
+    @JoinColumn(name = "id_ingrediente", nullable = false)
+    private Ingrediente ingrediente;
+
+    @Column(nullable = false)
+    private Integer stock;
+
+    @Column(nullable = false)
+    private BigDecimal costo;
+
+    public IngredienteTienda() {
+    }
+
+    public IngredienteTienda(Tienda tienda, Ingrediente ingrediente, Integer stock, BigDecimal costo, LocalDate fechaCaducidad) {
+        this.tienda = tienda;
+        this.ingrediente = ingrediente;
+        this.stock = stock;
+        this.costo = costo;
+        this.id = new IngredienteTiendaId(tienda.getId(), ingrediente.getId(), fechaCaducidad);
+    }
+
+    public IngredienteTiendaId getId() {
+        return id;
+    }
+
+    public Tienda getTienda() {
+        return tienda;
+    }
+
+    public void setTienda(Tienda tienda) {
+        this.tienda = tienda;
+        if (tienda != null) {
+            this.id.setTiendaId(tienda.getId());
+        }
+    }
+
+    public Ingrediente getIngrediente() {
+        return ingrediente;
+    }
+
+    public void setIngrediente(Ingrediente ingrediente) {
+        this.ingrediente = ingrediente;
+        if (ingrediente != null) {
+            this.id.setIngredienteId(ingrediente.getId());
+        }
+    }
+
+    public Integer getStock() {
+        return stock;
+    }
+
+    public void setStock(Integer stock) {
+        this.stock = stock;
+    }
+
+    public BigDecimal getCosto() {
+        return costo;
+    }
+
+    public void setCosto(BigDecimal costo) {
+        this.costo = costo;
+    }
+
+    public void setFechaCaducidad(LocalDate fechaCaducidad) {
+        this.id.setFechaCaducidad(fechaCaducidad);
+    }
+
+    public LocalDate getFechaCaducidad() {
+        return this.id.getFechaCaducidad();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof IngredienteTienda that)) return false;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/org/cerveza/cafe/model/IngredienteTiendaId.java
+++ b/src/main/java/org/cerveza/cafe/model/IngredienteTiendaId.java
@@ -1,0 +1,68 @@
+package org.cerveza.cafe.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.util.Objects;
+
+@Embeddable
+public class IngredienteTiendaId implements Serializable {
+
+    @Column(name = "id_tienda")
+    private Long tiendaId;
+
+    @Column(name = "id_ingrediente")
+    private Long ingredienteId;
+
+    @Column(name = "fecha_caducidad")
+    private LocalDate fechaCaducidad;
+
+    public IngredienteTiendaId() {
+    }
+
+    public IngredienteTiendaId(Long tiendaId, Long ingredienteId, LocalDate fechaCaducidad) {
+        this.tiendaId = tiendaId;
+        this.ingredienteId = ingredienteId;
+        this.fechaCaducidad = fechaCaducidad;
+    }
+
+    public Long getTiendaId() {
+        return tiendaId;
+    }
+
+    public void setTiendaId(Long tiendaId) {
+        this.tiendaId = tiendaId;
+    }
+
+    public Long getIngredienteId() {
+        return ingredienteId;
+    }
+
+    public void setIngredienteId(Long ingredienteId) {
+        this.ingredienteId = ingredienteId;
+    }
+
+    public LocalDate getFechaCaducidad() {
+        return fechaCaducidad;
+    }
+
+    public void setFechaCaducidad(LocalDate fechaCaducidad) {
+        this.fechaCaducidad = fechaCaducidad;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof IngredienteTiendaId that)) return false;
+        return Objects.equals(tiendaId, that.tiendaId) &&
+               Objects.equals(ingredienteId, that.ingredienteId) &&
+               Objects.equals(fechaCaducidad, that.fechaCaducidad);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tiendaId, ingredienteId, fechaCaducidad);
+    }
+}

--- a/src/main/java/org/cerveza/cafe/model/Inventario.java
+++ b/src/main/java/org/cerveza/cafe/model/Inventario.java
@@ -1,0 +1,89 @@
+package org.cerveza.cafe.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.Table;
+
+import java.util.Objects;
+
+@Entity
+@Table(name = "inventario")
+public class Inventario {
+
+    @EmbeddedId
+    private InventarioId id = new InventarioId();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("tiendaId")
+    @JoinColumn(name = "id_tienda", nullable = false)
+    private Tienda tienda;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("productoId")
+    @JoinColumn(name = "id_producto", nullable = false)
+    private Producto producto;
+
+    @Column(nullable = false)
+    private Integer stock;
+
+    public Inventario() {
+    }
+
+    public Inventario(Tienda tienda, Producto producto, Integer stock) {
+        this.tienda = tienda;
+        this.producto = producto;
+        this.stock = stock;
+        this.id = new InventarioId(tienda.getId(), producto.getId());
+    }
+
+    public InventarioId getId() {
+        return id;
+    }
+
+    public Tienda getTienda() {
+        return tienda;
+    }
+
+    public void setTienda(Tienda tienda) {
+        this.tienda = tienda;
+        if (tienda != null) {
+            this.id.setTiendaId(tienda.getId());
+        }
+    }
+
+    public Producto getProducto() {
+        return producto;
+    }
+
+    public void setProducto(Producto producto) {
+        this.producto = producto;
+        if (producto != null) {
+            this.id.setProductoId(producto.getId());
+        }
+    }
+
+    public Integer getStock() {
+        return stock;
+    }
+
+    public void setStock(Integer stock) {
+        this.stock = stock;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Inventario that)) return false;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/org/cerveza/cafe/model/InventarioId.java
+++ b/src/main/java/org/cerveza/cafe/model/InventarioId.java
@@ -1,0 +1,54 @@
+package org.cerveza.cafe.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+public class InventarioId implements Serializable {
+
+    @Column(name = "id_tienda")
+    private Long tiendaId;
+
+    @Column(name = "id_producto")
+    private Long productoId;
+
+    public InventarioId() {
+    }
+
+    public InventarioId(Long tiendaId, Long productoId) {
+        this.tiendaId = tiendaId;
+        this.productoId = productoId;
+    }
+
+    public Long getTiendaId() {
+        return tiendaId;
+    }
+
+    public void setTiendaId(Long tiendaId) {
+        this.tiendaId = tiendaId;
+    }
+
+    public Long getProductoId() {
+        return productoId;
+    }
+
+    public void setProductoId(Long productoId) {
+        this.productoId = productoId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof InventarioId that)) return false;
+        return Objects.equals(tiendaId, that.tiendaId) &&
+               Objects.equals(productoId, that.productoId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tiendaId, productoId);
+    }
+}

--- a/src/main/java/org/cerveza/cafe/model/Paso.java
+++ b/src/main/java/org/cerveza/cafe/model/Paso.java
@@ -1,0 +1,72 @@
+package org.cerveza.cafe.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import java.util.Objects;
+
+@Entity
+@Table(name = "paso")
+public class Paso {
+
+    @Id
+    @Column(name = "id_paso")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "id_receta", nullable = false)
+    private Receta receta;
+
+    @Column(name = "base_descripcion", nullable = false, length = 1024)
+    private String descripcion;
+
+    public Paso() {
+    }
+
+    public Paso(Long id, Receta receta, String descripcion) {
+        this.id = id;
+        this.receta = receta;
+        this.descripcion = descripcion;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Receta getReceta() {
+        return receta;
+    }
+
+    public void setReceta(Receta receta) {
+        this.receta = receta;
+    }
+
+    public String getDescripcion() {
+        return descripcion;
+    }
+
+    public void setDescripcion(String descripcion) {
+        this.descripcion = descripcion;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Paso paso)) return false;
+        return Objects.equals(id, paso.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/org/cerveza/cafe/model/Producto.java
+++ b/src/main/java/org/cerveza/cafe/model/Producto.java
@@ -1,0 +1,114 @@
+package org.cerveza.cafe.model;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+@Entity
+@Table(name = "productos")
+public class Producto {
+
+    @Id
+    @Column(name = "id_producto")
+    private Long id;
+
+    @Column(nullable = false)
+    private String descripcion;
+
+    @Column(nullable = false)
+    private BigDecimal costo;
+
+    @Column(name = "precio_venta", nullable = false)
+    private BigDecimal precioVenta;
+
+    @OneToOne(mappedBy = "producto", cascade = CascadeType.ALL)
+    private Receta receta;
+
+    @OneToMany(mappedBy = "producto", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Inventario> inventarios = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "producto", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<ProductoVendido> ventas = new LinkedHashSet<>();
+
+    public Producto() {
+    }
+
+    public Producto(Long id, String descripcion, BigDecimal costo, BigDecimal precioVenta) {
+        this.id = id;
+        this.descripcion = descripcion;
+        this.costo = costo;
+        this.precioVenta = precioVenta;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getDescripcion() {
+        return descripcion;
+    }
+
+    public void setDescripcion(String descripcion) {
+        this.descripcion = descripcion;
+    }
+
+    public BigDecimal getCosto() {
+        return costo;
+    }
+
+    public void setCosto(BigDecimal costo) {
+        this.costo = costo;
+    }
+
+    public BigDecimal getPrecioVenta() {
+        return precioVenta;
+    }
+
+    public void setPrecioVenta(BigDecimal precioVenta) {
+        this.precioVenta = precioVenta;
+    }
+
+    public Receta getReceta() {
+        return receta;
+    }
+
+    public void setReceta(Receta receta) {
+        this.receta = receta;
+        if (receta != null && receta.getProducto() != this) {
+            receta.setProducto(this);
+        }
+    }
+
+    public Set<Inventario> getInventarios() {
+        return inventarios;
+    }
+
+    public Set<ProductoVendido> getVentas() {
+        return ventas;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Producto producto)) return false;
+        return Objects.equals(id, producto.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/org/cerveza/cafe/model/ProductoVendido.java
+++ b/src/main/java/org/cerveza/cafe/model/ProductoVendido.java
@@ -1,0 +1,112 @@
+package org.cerveza.cafe.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.Table;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Entity
+@Table(name = "producto_vendido")
+public class ProductoVendido {
+
+    @EmbeddedId
+    private ProductoVendidoId id = new ProductoVendidoId();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("tiendaId")
+    @JoinColumn(name = "id_tienda", nullable = false)
+    private Tienda tienda;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("productoId")
+    @JoinColumn(name = "id_producto", nullable = false)
+    private Producto producto;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "id_cliente")
+    private Cliente cliente;
+
+    @Column(name = "precio_venta", nullable = false)
+    private BigDecimal precioVenta;
+
+    public ProductoVendido() {
+    }
+
+    public ProductoVendido(Tienda tienda, Producto producto, Cliente cliente, LocalDateTime fechaCompra, BigDecimal precioVenta) {
+        this.tienda = tienda;
+        this.producto = producto;
+        this.cliente = cliente;
+        this.precioVenta = precioVenta;
+        this.id = new ProductoVendidoId(tienda.getId(), producto.getId(), fechaCompra);
+    }
+
+    public ProductoVendidoId getId() {
+        return id;
+    }
+
+    public LocalDateTime getFechaCompra() {
+        return id.getFechaCompra();
+    }
+
+    public void setFechaCompra(LocalDateTime fechaCompra) {
+        this.id.setFechaCompra(fechaCompra);
+    }
+
+    public Tienda getTienda() {
+        return tienda;
+    }
+
+    public void setTienda(Tienda tienda) {
+        this.tienda = tienda;
+        if (tienda != null) {
+            this.id.setTiendaId(tienda.getId());
+        }
+    }
+
+    public Producto getProducto() {
+        return producto;
+    }
+
+    public void setProducto(Producto producto) {
+        this.producto = producto;
+        if (producto != null) {
+            this.id.setProductoId(producto.getId());
+        }
+    }
+
+    public Cliente getCliente() {
+        return cliente;
+    }
+
+    public void setCliente(Cliente cliente) {
+        this.cliente = cliente;
+    }
+
+    public BigDecimal getPrecioVenta() {
+        return precioVenta;
+    }
+
+    public void setPrecioVenta(BigDecimal precioVenta) {
+        this.precioVenta = precioVenta;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ProductoVendido that)) return false;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/org/cerveza/cafe/model/ProductoVendidoId.java
+++ b/src/main/java/org/cerveza/cafe/model/ProductoVendidoId.java
@@ -1,0 +1,68 @@
+package org.cerveza.cafe.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Embeddable
+public class ProductoVendidoId implements Serializable {
+
+    @Column(name = "id_tienda")
+    private Long tiendaId;
+
+    @Column(name = "id_producto")
+    private Long productoId;
+
+    @Column(name = "fecha_compra")
+    private LocalDateTime fechaCompra;
+
+    public ProductoVendidoId() {
+    }
+
+    public ProductoVendidoId(Long tiendaId, Long productoId, LocalDateTime fechaCompra) {
+        this.tiendaId = tiendaId;
+        this.productoId = productoId;
+        this.fechaCompra = fechaCompra;
+    }
+
+    public Long getTiendaId() {
+        return tiendaId;
+    }
+
+    public void setTiendaId(Long tiendaId) {
+        this.tiendaId = tiendaId;
+    }
+
+    public Long getProductoId() {
+        return productoId;
+    }
+
+    public void setProductoId(Long productoId) {
+        this.productoId = productoId;
+    }
+
+    public LocalDateTime getFechaCompra() {
+        return fechaCompra;
+    }
+
+    public void setFechaCompra(LocalDateTime fechaCompra) {
+        this.fechaCompra = fechaCompra;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ProductoVendidoId that)) return false;
+        return Objects.equals(tiendaId, that.tiendaId) &&
+               Objects.equals(productoId, that.productoId) &&
+               Objects.equals(fechaCompra, that.fechaCompra);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tiendaId, productoId, fechaCompra);
+    }
+}

--- a/src/main/java/org/cerveza/cafe/model/ProporcionIngrediente.java
+++ b/src/main/java/org/cerveza/cafe/model/ProporcionIngrediente.java
@@ -1,0 +1,90 @@
+package org.cerveza.cafe.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.Table;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+@Entity
+@Table(name = "proporcion_ingrediente")
+public class ProporcionIngrediente {
+
+    @EmbeddedId
+    private ProporcionIngredienteId id = new ProporcionIngredienteId();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("recetaId")
+    @JoinColumn(name = "id_receta", nullable = false)
+    private Receta receta;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("ingredienteId")
+    @JoinColumn(name = "id_ingrediente", nullable = false)
+    private Ingrediente ingrediente;
+
+    @Column(nullable = false)
+    private BigDecimal medida;
+
+    public ProporcionIngrediente() {
+    }
+
+    public ProporcionIngrediente(Receta receta, Ingrediente ingrediente, BigDecimal medida) {
+        this.receta = receta;
+        this.ingrediente = ingrediente;
+        this.medida = medida;
+        this.id = new ProporcionIngredienteId(receta.getId(), ingrediente.getId());
+    }
+
+    public ProporcionIngredienteId getId() {
+        return id;
+    }
+
+    public Receta getReceta() {
+        return receta;
+    }
+
+    public void setReceta(Receta receta) {
+        this.receta = receta;
+        if (receta != null) {
+            this.id.setRecetaId(receta.getId());
+        }
+    }
+
+    public Ingrediente getIngrediente() {
+        return ingrediente;
+    }
+
+    public void setIngrediente(Ingrediente ingrediente) {
+        this.ingrediente = ingrediente;
+        if (ingrediente != null) {
+            this.id.setIngredienteId(ingrediente.getId());
+        }
+    }
+
+    public BigDecimal getMedida() {
+        return medida;
+    }
+
+    public void setMedida(BigDecimal medida) {
+        this.medida = medida;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ProporcionIngrediente that)) return false;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/org/cerveza/cafe/model/ProporcionIngredienteId.java
+++ b/src/main/java/org/cerveza/cafe/model/ProporcionIngredienteId.java
@@ -1,0 +1,54 @@
+package org.cerveza.cafe.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+public class ProporcionIngredienteId implements Serializable {
+
+    @Column(name = "id_receta")
+    private Long recetaId;
+
+    @Column(name = "id_ingrediente")
+    private Long ingredienteId;
+
+    public ProporcionIngredienteId() {
+    }
+
+    public ProporcionIngredienteId(Long recetaId, Long ingredienteId) {
+        this.recetaId = recetaId;
+        this.ingredienteId = ingredienteId;
+    }
+
+    public Long getRecetaId() {
+        return recetaId;
+    }
+
+    public void setRecetaId(Long recetaId) {
+        this.recetaId = recetaId;
+    }
+
+    public Long getIngredienteId() {
+        return ingredienteId;
+    }
+
+    public void setIngredienteId(Long ingredienteId) {
+        this.ingredienteId = ingredienteId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ProporcionIngredienteId that)) return false;
+        return Objects.equals(recetaId, that.recetaId) &&
+               Objects.equals(ingredienteId, that.ingredienteId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(recetaId, ingredienteId);
+    }
+}

--- a/src/main/java/org/cerveza/cafe/model/Receta.java
+++ b/src/main/java/org/cerveza/cafe/model/Receta.java
@@ -1,0 +1,94 @@
+package org.cerveza.cafe.model;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+@Entity
+@Table(name = "receta")
+public class Receta {
+
+    @Id
+    @Column(name = "id_receta")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "id_producto", nullable = false, unique = true)
+    private Producto producto;
+
+    @Column(name = "costo_preparacion", nullable = false)
+    private BigDecimal costoPreparacion;
+
+    @OneToMany(mappedBy = "receta", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<ProporcionIngrediente> ingredientes = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "receta", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Paso> pasos = new LinkedHashSet<>();
+
+    public Receta() {
+    }
+
+    public Receta(Long id, Producto producto, BigDecimal costoPreparacion) {
+        this.id = id;
+        this.producto = producto;
+        this.costoPreparacion = costoPreparacion;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Producto getProducto() {
+        return producto;
+    }
+
+    public void setProducto(Producto producto) {
+        this.producto = producto;
+        if (producto != null && producto.getReceta() != this) {
+            producto.setReceta(this);
+        }
+    }
+
+    public BigDecimal getCostoPreparacion() {
+        return costoPreparacion;
+    }
+
+    public void setCostoPreparacion(BigDecimal costoPreparacion) {
+        this.costoPreparacion = costoPreparacion;
+    }
+
+    public Set<ProporcionIngrediente> getIngredientes() {
+        return ingredientes;
+    }
+
+    public Set<Paso> getPasos() {
+        return pasos;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Receta receta)) return false;
+        return Objects.equals(id, receta.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/org/cerveza/cafe/model/Tienda.java
+++ b/src/main/java/org/cerveza/cafe/model/Tienda.java
@@ -1,0 +1,113 @@
+package org.cerveza.cafe.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+@Entity
+@Table(name = "tienda")
+public class Tienda {
+
+    @Id
+    @Column(name = "id_tienda")
+    private Long id;
+
+    @Column(nullable = false)
+    private String nombre;
+
+    @Column
+    private String telefono;
+
+    @Column
+    private String direccion;
+
+    @Column(name = "empleado_responsable")
+    private String empleadoResponsable;
+
+    @OneToMany(mappedBy = "tienda")
+    private Set<Inventario> inventario = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "tienda")
+    private Set<ProductoVendido> ventas = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "tienda")
+    private Set<IngredienteTienda> ingredientes = new LinkedHashSet<>();
+
+    public Tienda() {
+    }
+
+    public Tienda(Long id, String nombre) {
+        this.id = id;
+        this.nombre = nombre;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public String getTelefono() {
+        return telefono;
+    }
+
+    public void setTelefono(String telefono) {
+        this.telefono = telefono;
+    }
+
+    public String getDireccion() {
+        return direccion;
+    }
+
+    public void setDireccion(String direccion) {
+        this.direccion = direccion;
+    }
+
+    public String getEmpleadoResponsable() {
+        return empleadoResponsable;
+    }
+
+    public void setEmpleadoResponsable(String empleadoResponsable) {
+        this.empleadoResponsable = empleadoResponsable;
+    }
+
+    public Set<Inventario> getInventario() {
+        return inventario;
+    }
+
+    public Set<ProductoVendido> getVentas() {
+        return ventas;
+    }
+
+    public Set<IngredienteTienda> getIngredientes() {
+        return ingredientes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Tienda tienda)) return false;
+        return Objects.equals(id, tienda.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             version="3.1"
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence https://jakarta.ee/xml/ns/persistence/persistence_3_1.xsd">
+    <persistence-unit name="CafePU" transaction-type="RESOURCE_LOCAL">
+        <provider>com.objectdb.jpa.Provider</provider>
+        <class>org.cerveza.cafe.model.Producto</class>
+        <class>org.cerveza.cafe.model.Receta</class>
+        <class>org.cerveza.cafe.model.ProporcionIngrediente</class>
+        <class>org.cerveza.cafe.model.Paso</class>
+        <class>org.cerveza.cafe.model.Ingrediente</class>
+        <class>org.cerveza.cafe.model.Inventario</class>
+        <class>org.cerveza.cafe.model.Tienda</class>
+        <class>org.cerveza.cafe.model.Cliente</class>
+        <class>org.cerveza.cafe.model.ProductoVendido</class>
+        <class>org.cerveza.cafe.model.IngredienteTienda</class>
+        <properties>
+            <property name="jakarta.persistence.jdbc.url" value="$objectdb/db/cafe.odb"/>
+            <property name="objectdb.temp.no-detached" value="true"/>
+        </properties>
+    </persistence-unit>
+</persistence>


### PR DESCRIPTION
## Summary
- add a complete set of JPA entities that model the cafe domain for ObjectDB
- expose the new model package through the module descriptor and register the persistence unit
- configure a persistence unit for ObjectDB to generate the database schema

## Testing
- mvn -q -DskipTests compile *(fails: invalid target release: 24 in container JDK)*

------
https://chatgpt.com/codex/tasks/task_e_68daaaa00588832e9a869a2d97b550ab