### PR TITLE
Mostrar dumps registrados y guardar base en Downloads

### DIFF
--- a/src/main/java/org/cerveza/cafe/DatabaseManager.java
+++ b/src/main/java/org/cerveza/cafe/DatabaseManager.java
@@ -1,0 +1,135 @@
+package org.cerveza.cafe;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Persistence;
+import org.cerveza.cafe.model.Cliente;
+import org.cerveza.cafe.model.DumpRecord;
+import org.cerveza.cafe.model.Producto;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Gestiona el ciclo de vida del {@link EntityManagerFactory} y el archivo de base de datos.
+ */
+public final class DatabaseManager {
+
+    private static EntityManagerFactory entityManagerFactory;
+    private static Path databasePath;
+
+    private DatabaseManager() {
+        // Utility class
+    }
+
+    /**
+     * Inicializa el {@link EntityManagerFactory} si todavía no se ha creado.
+     */
+    public static synchronized void initialize() {
+        if (entityManagerFactory != null) {
+            return;
+        }
+
+        try {
+            databasePath = resolveDatabasePath();
+            Files.createDirectories(databasePath.getParent());
+        } catch (IOException e) {
+            throw new IllegalStateException("No se pudo preparar el directorio de la base de datos", e);
+        }
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put("jakarta.persistence.jdbc.url", databasePath.toString());
+        properties.put("javax.persistence.jdbc.url", databasePath.toString());
+
+        entityManagerFactory = Persistence.createEntityManagerFactory("CafePU", properties);
+
+        seedDatabase();
+    }
+
+    private static Path resolveDatabasePath() {
+        String userHome = System.getProperty("user.home");
+        Path downloadsDir = Paths.get(userHome, "Downloads");
+        return downloadsDir.resolve("cafe.odb").toAbsolutePath();
+    }
+
+    /**
+     * Libera los recursos asociados al {@link EntityManagerFactory}.
+     */
+    public static synchronized void shutdown() {
+        if (entityManagerFactory != null) {
+            entityManagerFactory.close();
+            entityManagerFactory = null;
+        }
+    }
+
+    public static EntityManagerFactory getEntityManagerFactory() {
+        if (entityManagerFactory == null) {
+            throw new IllegalStateException("La base de datos no ha sido inicializada.");
+        }
+        return entityManagerFactory;
+    }
+
+    public static Path getDatabasePath() {
+        if (databasePath == null) {
+            throw new IllegalStateException("La base de datos no ha sido inicializada.");
+        }
+        return databasePath;
+    }
+
+    private static void seedDatabase() {
+        EntityManager entityManager = entityManagerFactory.createEntityManager();
+
+        try {
+            entityManager.getTransaction().begin();
+
+            long clientes = entityManager.createQuery("SELECT COUNT(c) FROM Cliente c", Long.class)
+                    .getSingleResult();
+            long productos = entityManager.createQuery("SELECT COUNT(p) FROM Producto p", Long.class)
+                    .getSingleResult();
+            long dumps = entityManager.createQuery("SELECT COUNT(d) FROM DumpRecord d", Long.class)
+                    .getSingleResult();
+
+            if (clientes == 0L && productos == 0L) {
+                Cliente ana = new Cliente(1L, "Ana Torres");
+                ana.setTelefono("555-0101");
+                ana.setCorreo("ana@example.com");
+
+                Cliente marco = new Cliente(2L, "Marco Díaz");
+                marco.setTelefono("555-0202");
+                marco.setCorreo("marco@example.com");
+
+                Producto espresso = new Producto(1L, "Espresso", new BigDecimal("12.50"), new BigDecimal("30.00"));
+                Producto capuccino = new Producto(2L, "Capuccino", new BigDecimal("15.00"), new BigDecimal("38.00"));
+
+                entityManager.persist(ana);
+                entityManager.persist(marco);
+                entityManager.persist(espresso);
+                entityManager.persist(capuccino);
+            }
+
+            if (dumps == 0L) {
+                DumpRecord dumpRecord = new DumpRecord(
+                        databasePath.getFileName().toString(),
+                        databasePath.toString(),
+                        LocalDateTime.now()
+                );
+                entityManager.persist(dumpRecord);
+            }
+
+            entityManager.getTransaction().commit();
+        } catch (Exception e) {
+            if (entityManager.getTransaction().isActive()) {
+                entityManager.getTransaction().rollback();
+            }
+            throw e;
+        } finally {
+            entityManager.close();
+        }
+    }
+}

--- a/src/main/java/org/cerveza/cafe/DumpListController.java
+++ b/src/main/java/org/cerveza/cafe/DumpListController.java
@@ -1,0 +1,73 @@
+package org.cerveza.cafe;
+
+import jakarta.persistence.EntityManager;
+import javafx.beans.property.ReadOnlyObjectWrapper;
+import javafx.beans.property.ReadOnlyStringWrapper;
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.control.TableCell;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
+import org.cerveza.cafe.model.DumpRecord;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+public class DumpListController {
+
+    @FXML
+    private TableView<DumpRecord> dumpTable;
+
+    @FXML
+    private TableColumn<DumpRecord, Long> idColumn;
+
+    @FXML
+    private TableColumn<DumpRecord, String> fileNameColumn;
+
+    @FXML
+    private TableColumn<DumpRecord, String> pathColumn;
+
+    @FXML
+    private TableColumn<DumpRecord, LocalDateTime> createdColumn;
+
+    @FXML
+    private Label databaseLocationLabel;
+
+    private final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+
+    @FXML
+    public void initialize() {
+        idColumn.setCellValueFactory(data -> new ReadOnlyObjectWrapper<>(data.getValue().getId()));
+        fileNameColumn.setCellValueFactory(data -> new ReadOnlyStringWrapper(data.getValue().getNombreArchivo()));
+        pathColumn.setCellValueFactory(data -> new ReadOnlyStringWrapper(data.getValue().getRutaArchivo()));
+        createdColumn.setCellValueFactory(data -> new ReadOnlyObjectWrapper<>(data.getValue().getFechaCreacion()));
+        createdColumn.setCellFactory(column -> new TableCell<>() {
+            @Override
+            protected void updateItem(LocalDateTime item, boolean empty) {
+                super.updateItem(item, empty);
+                if (empty || item == null) {
+                    setText(null);
+                } else {
+                    setText(dateFormatter.format(item));
+                }
+            }
+        });
+
+        databaseLocationLabel.setText(DatabaseManager.getDatabasePath().toString());
+
+        loadDumpRecords();
+    }
+
+    private void loadDumpRecords() {
+        EntityManager entityManager = DatabaseManager.getEntityManagerFactory().createEntityManager();
+        try {
+            List<DumpRecord> records = entityManager
+                    .createQuery("SELECT d FROM DumpRecord d ORDER BY d.fechaCreacion DESC", DumpRecord.class)
+                    .getResultList();
+            dumpTable.getItems().setAll(records);
+        } finally {
+            entityManager.close();
+        }
+    }
+}

--- a/src/main/java/org/cerveza/cafe/HelloApplication.java
+++ b/src/main/java/org/cerveza/cafe/HelloApplication.java
@@ -8,11 +8,26 @@ import javafx.stage.Stage;
 import java.io.IOException;
 
 public class HelloApplication extends Application {
+
+    public static void main(String[] args) {
+        launch(args);
+    }
+
+    @Override
+    public void init() {
+        DatabaseManager.initialize();
+    }
+
+    @Override
+    public void stop() {
+        DatabaseManager.shutdown();
+    }
+
     @Override
     public void start(Stage stage) throws IOException {
-        FXMLLoader fxmlLoader = new FXMLLoader(HelloApplication.class.getResource("hello-view.fxml"));
-        Scene scene = new Scene(fxmlLoader.load(), 320, 240);
-        stage.setTitle("Hello!");
+        FXMLLoader fxmlLoader = new FXMLLoader(HelloApplication.class.getResource("dump-list-view.fxml"));
+        Scene scene = new Scene(fxmlLoader.load(), 900, 480);
+        stage.setTitle("Historial de dumps de base de datos");
         stage.setScene(scene);
         stage.show();
     }

--- a/src/main/java/org/cerveza/cafe/Launcher.java
+++ b/src/main/java/org/cerveza/cafe/Launcher.java
@@ -1,72 +1,9 @@
 package org.cerveza.cafe;
 
 import javafx.application.Application;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.EntityManagerFactory;
-import jakarta.persistence.Persistence;
-import org.cerveza.cafe.model.Cliente;
-import org.cerveza.cafe.model.Producto;
-
-import java.math.BigDecimal;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.HashMap;
-import java.util.Map;
 
 public class Launcher {
     public static void main(String[] args) {
-        seedDatabase();
-        System.out.println("OKKKKK");
-    }
-
-    private static void seedDatabase() {
-        try {
-            Path dbPath = Paths.get("target", "database", "cafe.odb").toAbsolutePath();
-            Files.createDirectories(dbPath.getParent());
-
-            Map<String, String> properties = new HashMap<>();
-            properties.put("jakarta.persistence.jdbc.url", dbPath.toString());
-
-            EntityManagerFactory emf = Persistence.createEntityManagerFactory("CafePU", properties);
-            EntityManager entityManager = emf.createEntityManager();
-
-            try {
-                Long clientes = entityManager.createQuery("SELECT COUNT(c) FROM Cliente c", Long.class)
-                        .getSingleResult();
-
-                if (clientes == 0L) {
-                    entityManager.getTransaction().begin();
-
-                    Cliente ana = new Cliente(1L, "Ana Torres");
-                    ana.setTelefono("555-0101");
-                    ana.setCorreo("ana@example.com");
-
-                    Cliente marco = new Cliente(2L, "Marco Díaz");
-                    marco.setTelefono("555-0202");
-                    marco.setCorreo("marco@example.com");
-
-                    Producto espresso = new Producto(1L, "Espresso", new BigDecimal("12.50"), new BigDecimal("30.00"));
-                    Producto capuccino = new Producto(2L, "Capuccino", new BigDecimal("15.00"), new BigDecimal("38.00"));
-
-                    entityManager.persist(ana);
-                    entityManager.persist(marco);
-                    entityManager.persist(espresso);
-                    entityManager.persist(capuccino);
-
-                    entityManager.getTransaction().commit();
-                }
-            } catch (Exception e) {
-                if (entityManager.getTransaction().isActive()) {
-                    entityManager.getTransaction().rollback();
-                }
-                throw e;
-            } finally {
-                entityManager.close();
-                emf.close();
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        Application.launch(HelloApplication.class, args);
     }
 }

--- a/src/main/java/org/cerveza/cafe/model/DumpRecord.java
+++ b/src/main/java/org/cerveza/cafe/model/DumpRecord.java
@@ -1,0 +1,78 @@
+package org.cerveza.cafe.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Entity
+@Table(name = "dump_record")
+public class DumpRecord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "nombre_archivo", nullable = false)
+    private String nombreArchivo;
+
+    @Column(name = "ruta_archivo", nullable = false)
+    private String rutaArchivo;
+
+    @Column(name = "fecha_creacion", nullable = false)
+    private LocalDateTime fechaCreacion;
+
+    public DumpRecord() {
+    }
+
+    public DumpRecord(String nombreArchivo, String rutaArchivo, LocalDateTime fechaCreacion) {
+        this.nombreArchivo = nombreArchivo;
+        this.rutaArchivo = rutaArchivo;
+        this.fechaCreacion = fechaCreacion;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getNombreArchivo() {
+        return nombreArchivo;
+    }
+
+    public void setNombreArchivo(String nombreArchivo) {
+        this.nombreArchivo = nombreArchivo;
+    }
+
+    public String getRutaArchivo() {
+        return rutaArchivo;
+    }
+
+    public void setRutaArchivo(String rutaArchivo) {
+        this.rutaArchivo = rutaArchivo;
+    }
+
+    public LocalDateTime getFechaCreacion() {
+        return fechaCreacion;
+    }
+
+    public void setFechaCreacion(LocalDateTime fechaCreacion) {
+        this.fechaCreacion = fechaCreacion;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof DumpRecord that)) return false;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/resources/org/cerveza/cafe/dump-list-view.fxml
+++ b/src/main/resources/org/cerveza/cafe/dump-list-view.fxml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.TableColumn?>
+<?import javafx.scene.control.TableView?>
+<?import javafx.scene.layout.BorderPane?>
+<?import javafx.scene.layout.VBox?>
+
+<BorderPane xmlns:fx="http://javafx.com/fxml" fx:controller="org.cerveza.cafe.DumpListController">
+    <top>
+        <VBox spacing="8.0" style="-fx-padding: 16;">
+            <Label text="Listado de dumps registrados" style="-fx-font-size: 18px; -fx-font-weight: bold;" />
+            <Label fx:id="databaseLocationLabel" text="" wrapText="true" />
+        </VBox>
+    </top>
+    <center>
+        <TableView fx:id="dumpTable" prefHeight="200.0" prefWidth="200.0">
+            <columns>
+                <TableColumn fx:id="idColumn" prefWidth="80.0" text="ID" />
+                <TableColumn fx:id="fileNameColumn" prefWidth="200.0" text="Archivo" />
+                <TableColumn fx:id="pathColumn" prefWidth="420.0" text="Ruta" />
+                <TableColumn fx:id="createdColumn" prefWidth="180.0" text="Fecha de creación" />
+            </columns>
+        </TableView>
+    </center>
+</BorderPane>


### PR DESCRIPTION
## Summary
- centralizar la creación de la base de datos ObjectDB en un gestor que la guarda en la carpeta Downloads
- añadir la entidad DumpRecord y sembrar un registro con la ruta del archivo generado
- crear una nueva vista JavaFX que lista los dumps guardados y muestra la ubicación del archivo

## Testing
- mvn -q -DskipTests compile *(falla: invalid target release 24 en el entorno actual)*

------
https://chatgpt.com/codex/tasks/task_e_68dadf2e79d8832e9c1ffaa4fe574958